### PR TITLE
Update AppDelegate.swift

### DIFF
--- a/Xylophone/AppDelegate.swift
+++ b/Xylophone/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         return true
     }
 


### PR DESCRIPTION
Received the following error: 'UIApplicationLaunchOptionsKey' has been renamed to 'UIApplication.LaunchOptionsKey'

I made that fix.